### PR TITLE
Allow older versions of NodeJS in package.json engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "src/index.js",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=16.0.0"
   },
   "scripts": {
     "build-dts": "rm -f src/*.d.ts && tsc --emitDeclarationOnly && prettier src/*.d.ts --write",


### PR DESCRIPTION
There doesn't seem to be anything restricting this to Node 18+, could we support for older versions of Node by updating the engines field?