### PR TITLE
CI: scope OIDC id-token to the publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,13 +6,12 @@ on:
       - 'v*'
   # pull_request:
 
-permissions:
-  contents: read
-  id-token: write
-
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
Moves \`permissions\` (including \`id-token: write\`) from **workflow-level** to the **publish job** so only that job can mint an OIDC token for npm trusted publishing.

Least-privilege hardening per the npm trusted-publishing / OIDC supply-chain guidance (Snyk advisory, Step 4). Functionally identical (single job) but tightens the OIDC blast radius.

Note: the registry-side trusted-publisher config (npmjs.com) should also be pinned to this specific repo + workflow file (\`publish.yml\`) and ideally a GitHub Environment — that part is an npm settings change, not in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)